### PR TITLE
fix: don't replace invalid imports with `undefined`

### DIFF
--- a/script/update.ts
+++ b/script/update.ts
@@ -122,7 +122,7 @@ async function updateFile(path: string, {
       }
 
       content = content.replace(REGEX, (_, identifier) => {
-        return identifiers[identifier]
+        return identifiers[identifier] ?? _
       })
     }
 


### PR DESCRIPTION
fixes #33 